### PR TITLE
Adding iframe top and left for consistent positioning

### DIFF
--- a/xrayquire.js
+++ b/xrayquire.js
@@ -290,6 +290,8 @@ var xrayquire;
             iframe.style.background  = "#888";
             iframe.style.width       = "100%";
             iframe.style.height      = "100%";
+            iframe.style.top         = "0px";
+            iframe.style.left        = "0px";
             // --
             var iframeDoc = iframe.contentWindow.document;
             iframeDoc.body.innerHTML = html;


### PR DESCRIPTION
On my test page, I existing positioning that prevents the iframe from showing up. By settings the top and left, the iframe consistently shows up above the page content.
